### PR TITLE
meta: distinct brand color for light

### DIFF
--- a/data/io.github.leolost2605.emergency-alerts.metainfo.xml.in
+++ b/data/io.github.leolost2605.emergency-alerts.metainfo.xml.in
@@ -34,7 +34,7 @@
   <launchable type="desktop-id">io.github.leolost2605.emergency-alerts.desktop</launchable>
 
   <branding>
-    <color type="primary" scheme_preference="light">#032f9c</color>
+    <color type="primary" scheme_preference="light">#7eb9ed</color>
     <color type="primary" scheme_preference="dark">#032f9c</color>
   </branding>
 


### PR DESCRIPTION
Add a distinct, lighter brand color for light.

![image](https://github.com/user-attachments/assets/52ebf4d9-0857-45a0-acb2-6579853e1c96)
